### PR TITLE
Override time zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,19 @@ const dateTime = translator.d(new Date(), 'time') // e.g. '18:08:05' in de-DE
 A full [`Intl.DateTimeFormatOptions`][5] set of options can also be specified
 as a second parameter to fine-tune the formatting.
 
+The third parameter, if specified, can be used to override the default time
+zone when formatting:
+
+```typescript
+import { useTranslator } from '@juit/vue-i18n'
+
+const translator = useTranslator()
+
+translator.d(new Date(), 'full', 'Europe/Berlin')
+// e.g. Monday, 3 February 2025 at 18:08:03 Central European Standard Time
+```
+
+
 
 ## Configuring Types
 

--- a/lib/translator.ts
+++ b/lib/translator.ts
@@ -94,7 +94,7 @@ export interface Translator {
    * format. This can be one of the aliases specified at initialization, or a
    * fully-fledged `Intl.DateTimeFormatOptions` object.
    */
-  d(date?: DateInput, format?: DateTimeFormatAlias | Intl.DateTimeFormatOptions): string
+  d(date?: DateInput, format?: DateTimeFormatAlias | Intl.DateTimeFormatOptions, timeZone?: string): string
 
   /** Extra internationalization utilities */
   utils: {
@@ -145,7 +145,7 @@ export function makeTranslator(options: I18nOptions): Translator {
       defaultLocale.language
 
   // Default time zone
-  const timeZone = options.defaultTimeZone
+  const defaultTimeZone = options.defaultTimeZone
 
   const translations: InternalTranslations = options.translations ? structuredClone(options.translations) : {}
   const dateTimeFormats: DateTimeFormats = {
@@ -244,7 +244,7 @@ export function makeTranslator(options: I18nOptions): Translator {
       return replaceParams(template, Object.assign({ n }, params), format)
     },
 
-    d(input?: DateInput, format: DateTimeFormatAlias | Intl.DateTimeFormatOptions = 'default'): string {
+    d(input?: DateInput, format: DateTimeFormatAlias | Intl.DateTimeFormatOptions = 'default', timeZone?: string): string {
       if ((input == null) || (input === '')) return ''
 
       const date = input instanceof Date ? input : new Date(input)
@@ -252,7 +252,7 @@ export function makeTranslator(options: I18nOptions): Translator {
       if (! options) warn(`DateTimeFormat alias "${format}" not found`)
 
       // Merge the default time zone with the options
-      const optionsWithTimeZone = { timeZone, ...options }
+      const optionsWithTimeZone = { timeZone: timeZone || defaultTimeZone, ...options }
 
       // Format our date, optionally defaulting the time zone
       return new Intl.DateTimeFormat(locale.value, optionsWithTimeZone).format(date)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@juit/vue-i18n",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@juit/vue-i18n",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@plugjs/eslint-plugin": "^0.3.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/vue-i18n",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "exports": {
     ".": {

--- a/test/01-i18n.test.ts
+++ b/test/01-i18n.test.ts
@@ -260,6 +260,25 @@ describe('I18N Plugin', () => {
       timeZone: 'America/New_York',
     })
     expect(result2).toEqual('13/02/2009, 18:31:30.123 GMT-05:00')
+
+    const result3 = translator.d(date, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      fractionalSecondDigits: 3,
+      timeZoneName: 'longOffset',
+    }, 'Asia/Tokyo')
+    expect(result3).toEqual('14/02/2009, 08:31:30.123 GMT+09:00')
+
+    const result4 = translator.d(date, 'full')
+    expect(result4).toEqual('Friday, 13 February 2009 at 23:31:30 Coordinated Universal Time')
+
+    const result5 = translator.d(date, 'full', 'Pacific/Auckland')
+    expect(result5).toEqual('Saturday, 14 February 2009 at 12:31:30 New Zealand Daylight Time')
   })
 
   it('should format a number in various languages with object formats', (context) => {

--- a/test/01-i18n.test.ts
+++ b/test/01-i18n.test.ts
@@ -274,11 +274,11 @@ describe('I18N Plugin', () => {
     }, 'Asia/Tokyo')
     expect(result3).toEqual('14/02/2009, 08:31:30.123 GMT+09:00')
 
-    const result4 = translator.d(date, 'full')
-    expect(result4).toEqual('Friday, 13 February 2009 at 23:31:30 Coordinated Universal Time')
+    const result4 = translator.d(date, 'short')
+    expect(result4).toEqual('13/02/2009, 23:31')
 
-    const result5 = translator.d(date, 'full', 'Pacific/Auckland')
-    expect(result5).toEqual('Saturday, 14 February 2009 at 12:31:30 New Zealand Daylight Time')
+    const result5 = translator.d(date, 'short', 'Pacific/Auckland')
+    expect(result5).toEqual('14/02/2009, 12:31')
   })
 
   it('should format a number in various languages with object formats', (context) => {


### PR DESCRIPTION
Add a third parameter to `d(...)` to override the _default_ timezone.